### PR TITLE
Fix issue with Thrown Pencils on client side

### DIFF
--- a/GatorRando/questMods/SamQuestMods.cs
+++ b/GatorRando/questMods/SamQuestMods.cs
@@ -20,6 +20,7 @@ static class SamQuestMods
         {
             DialogueSequencer sequencer = seq.GetComponent<DialogueSequencer>();
             sequencer.afterSequence.ObliteratePersistentListenerByIndex(0);
+            sequencer.afterSequence.AddListener(UpdateSamState);
             DSItem item = seq.GetComponent<DSItem>();
             item.item = Util.GenerateItemObject(itemName, item.item.sprite);
         }


### PR DESCRIPTION
add listener to Sam to make sure Sam's state is updated at each stage of Sam's quest if Thrown Pencils are already received

Resolves #49 