### PR TITLE
Saves location checked in game into save data

### DIFF
--- a/GatorRando/ArchipelagoManager.cs
+++ b/GatorRando/ArchipelagoManager.cs
@@ -31,6 +31,8 @@ public static class ArchipelagoManager
     public static int GetItemUnlockCount(string itemName) =>
         Session.Items.AllItemsReceived.Where(itemInfo => itemInfo.ItemId == GetItemApId(itemName)).Count();
 
+    public static bool CheckIfLocationInSave(int id) => Util.FindKeysByPrefix("AP ID: ").Contains(id.ToString());
+
     public static bool IsFullyConnected
     {
         get => Session is not null

--- a/GatorRando/ArchipelagoManager.cs
+++ b/GatorRando/ArchipelagoManager.cs
@@ -212,7 +212,7 @@ public static class ArchipelagoManager
 
         static void TriggerLocationListeners()
         {
-            ReadOnlyCollection<long> locationsCollected = [];
+            ReadOnlyCollection<long> locationsCollected;
             if (LocationAutoCollect)
             {
                 locationsCollected = Session.Locations.AllLocationsChecked;

--- a/GatorRando/ArchipelagoManager.cs
+++ b/GatorRando/ArchipelagoManager.cs
@@ -19,7 +19,7 @@ public static class ArchipelagoManager
     private static readonly Dictionary<string, Action> SpecialItemFunctions = [];
     private static readonly Dictionary<string, Action> SpecialLocationFunctions = [];
     public static bool LocationAutoCollect = true;
-    private static readonly string locationKeyPrefix = "AP ID: ";
+    private static readonly string LocationKeyPrefix = "AP ID: ";
     public static void RegisterItemListener(string itemName, Action listener) => SpecialItemFunctions[itemName] = listener;
     public static void RegisterLocationListener(string locationName, Action listener) => SpecialLocationFunctions[locationName] = listener;
 
@@ -42,7 +42,7 @@ public static class ArchipelagoManager
     public static int GetItemUnlockCount(string itemName) =>
         Session.Items.AllItemsReceived.Where(itemInfo => itemInfo.ItemId == GetItemApId(itemName)).Count();
 
-    public static bool CheckIfAPLocationInSave(long id) => Util.FindBoolKeysByPrefix(locationKeyPrefix).Contains(id.ToString());
+    public static bool CheckIfAPLocationInSave(long id) => Util.FindBoolKeysByPrefix(LocationKeyPrefix).Contains(id.ToString());
 
     public static bool IsFullyConnected
     {
@@ -179,7 +179,7 @@ public static class ArchipelagoManager
 
         static void SendLocallySavedLocations()
         {
-            foreach (long location in Util.FindBoolKeysByPrefix(locationKeyPrefix).Select(long.Parse))
+            foreach (long location in Util.FindBoolKeysByPrefix(LocationKeyPrefix).Select(long.Parse))
             {
                 if (!Session.Locations.AllLocationsChecked.Contains(location))
                 {
@@ -344,7 +344,7 @@ public static class ArchipelagoManager
             return false;
         }
 
-        GameData.g.Write(locationKeyPrefix + ap_id.ToString(), true);
+        GameData.g.Write(LocationKeyPrefix + ap_id.ToString(), true);
         CollectLocationByAPID(ap_id);
         return true;
     }
@@ -362,7 +362,7 @@ public static class ArchipelagoManager
             return false;
         }
 
-        GameData.g.Write(locationKeyPrefix + ap_id.ToString(), true);
+        GameData.g.Write(LocationKeyPrefix + ap_id.ToString(), true);
         CollectLocationByAPID(ap_id);
         return true;
     }

--- a/GatorRando/ArchipelagoManager.cs
+++ b/GatorRando/ArchipelagoManager.cs
@@ -118,9 +118,11 @@ public static class ArchipelagoManager
     public static void InitiateNewAPSession(Action postConnectAction)
     {
         Disconnect();
+
         (string server, int port) = GetServer();
         string user = GetUser();
         string password = GetPassword();
+        GetCollectBehavior(); // check user setting for collect behavior
         if (Connect(server, port, user, password))
         {
             // wait until Session is connected & knows about all its items
@@ -168,6 +170,11 @@ public static class ArchipelagoManager
             {
                 return passwordWithPrefix.Remove(0, passwordPrefix.Length);
             }
+        }
+
+        static void GetCollectBehavior()
+        {
+            LocationAutoCollect = Settings.s.ReadBool("!collect counts as checked", true);
         }
 
         static void SendLocallySavedLocations()

--- a/GatorRando/ArchipelagoManager.cs
+++ b/GatorRando/ArchipelagoManager.cs
@@ -172,7 +172,7 @@ public static class ArchipelagoManager
 
         static void SendLocallySavedLocations()
         {
-            foreach (long location in Util.FindKeysByPrefix("AP ID ").Select(long.Parse))
+            foreach (long location in Util.FindKeysByPrefix(location_key_prefix).Select(long.Parse))
             {
                 if (!Session.Locations.AllLocationsChecked.Contains(location))
                 {

--- a/GatorRando/ArchipelagoManager.cs
+++ b/GatorRando/ArchipelagoManager.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Collections.Concurrent;
 using Archipelago.MultiClient.Net.Packets;
 using Archipelago.MultiClient.Net.Models;
-using System.Collections.ObjectModel;
 
 namespace GatorRando;
 
@@ -327,7 +326,6 @@ public static class ArchipelagoManager
         try
         {
             ap_id = GetLocationApId(id);
-            GameData.g.Write(location_key_prefix + ap_id.ToString(), true);
         }
         catch (InvalidOperationException)
         {
@@ -338,6 +336,7 @@ public static class ArchipelagoManager
             return false;
         }
 
+        GameData.g.Write(location_key_prefix + ap_id.ToString(), true);
         CollectLocationByAPID(ap_id);
         return true;
     }
@@ -355,6 +354,7 @@ public static class ArchipelagoManager
             return false;
         }
 
+        GameData.g.Write(location_key_prefix + ap_id.ToString(), true);
         CollectLocationByAPID(ap_id);
         return true;
     }

--- a/GatorRando/ArchipelagoManager.cs
+++ b/GatorRando/ArchipelagoManager.cs
@@ -19,7 +19,7 @@ public static class ArchipelagoManager
     private static readonly Dictionary<string, Action> SpecialItemFunctions = [];
     private static readonly Dictionary<string, Action> SpecialLocationFunctions = [];
     public static bool LocationAutoCollect = true;
-    private static readonly string location_key_prefix = "AP ID: ";
+    private static readonly string locationKeyPrefix = "AP ID: ";
     public static void RegisterItemListener(string itemName, Action listener) => SpecialItemFunctions[itemName] = listener;
     public static void RegisterLocationListener(string locationName, Action listener) => SpecialLocationFunctions[locationName] = listener;
 
@@ -42,7 +42,7 @@ public static class ArchipelagoManager
     public static int GetItemUnlockCount(string itemName) =>
         Session.Items.AllItemsReceived.Where(itemInfo => itemInfo.ItemId == GetItemApId(itemName)).Count();
 
-    public static bool CheckIfAPLocationInSave(long id) => Util.FindBoolKeysByPrefix(location_key_prefix).Contains(id.ToString());
+    public static bool CheckIfAPLocationInSave(long id) => Util.FindBoolKeysByPrefix(locationKeyPrefix).Contains(id.ToString());
 
     public static bool IsFullyConnected
     {
@@ -179,7 +179,7 @@ public static class ArchipelagoManager
 
         static void SendLocallySavedLocations()
         {
-            foreach (long location in Util.FindBoolKeysByPrefix(location_key_prefix).Select(long.Parse))
+            foreach (long location in Util.FindBoolKeysByPrefix(locationKeyPrefix).Select(long.Parse))
             {
                 if (!Session.Locations.AllLocationsChecked.Contains(location))
                 {
@@ -344,7 +344,7 @@ public static class ArchipelagoManager
             return false;
         }
 
-        GameData.g.Write(location_key_prefix + ap_id.ToString(), true);
+        GameData.g.Write(locationKeyPrefix + ap_id.ToString(), true);
         CollectLocationByAPID(ap_id);
         return true;
     }
@@ -362,7 +362,7 @@ public static class ArchipelagoManager
             return false;
         }
 
-        GameData.g.Write(location_key_prefix + ap_id.ToString(), true);
+        GameData.g.Write(locationKeyPrefix + ap_id.ToString(), true);
         CollectLocationByAPID(ap_id);
         return true;
     }

--- a/GatorRando/ArchipelagoManager.cs
+++ b/GatorRando/ArchipelagoManager.cs
@@ -43,7 +43,7 @@ public static class ArchipelagoManager
     public static int GetItemUnlockCount(string itemName) =>
         Session.Items.AllItemsReceived.Where(itemInfo => itemInfo.ItemId == GetItemApId(itemName)).Count();
 
-    public static bool CheckIfAPLocationInSave(int id) => Util.FindKeysByPrefix(location_key_prefix).Contains(id.ToString());
+    public static bool CheckIfAPLocationInSave(long id) => Util.FindKeysByPrefix(location_key_prefix).Contains(id.ToString());
 
     public static bool IsFullyConnected
     {
@@ -253,14 +253,14 @@ public static class ArchipelagoManager
 
     public static ItemInfo ItemAtLocation(int gatorID)
     {
-        int ap_id = GetLocationApId(gatorID);
+        long ap_id = GetLocationApId(gatorID);
         return LocationLookup[ap_id];
         // Fails if invalid gatorID (only use on collected IDs?)
     }
 
     public static ItemInfo ItemAtLocation(string gatorName)
     {
-        int ap_id = GetLocationApId(gatorName);
+        long ap_id = GetLocationApId(gatorName);
         return LocationLookup[ap_id];
         // Fails if invalid gatorName (only use on collected IDs?)
     }
@@ -300,18 +300,18 @@ public static class ArchipelagoManager
     private static int GetItemApId(string gatorName) =>
         (int)Items.Entries.First(entry => entry.client_name_id == gatorName).ap_item_id;
 
-    private static int GetLocationApId(int gatorID) =>
-        (int)Locations.Entries.First(entry => entry.client_id == gatorID).ap_location_id;
+    private static long GetLocationApId(int gatorID) =>
+        (long)Locations.Entries.First(entry => entry.client_id == gatorID).ap_location_id;
 
-    private static int GetLocationApId(string gatorName) =>
-        (int)Locations.Entries.First(entry => entry.client_name_id == gatorName).ap_location_id;
+    private static long GetLocationApId(string gatorName) =>
+        (long)Locations.Entries.First(entry => entry.client_name_id == gatorName).ap_location_id;
 
-    private static void CollectLocationByAPID(int id) => Session.Locations.CompleteLocationChecks(id);
+    private static void CollectLocationByAPID(long id) => Session.Locations.CompleteLocationChecks(id);
 
 
     public static bool CollectLocationByID(int id)
     {
-        int ap_id;
+        long ap_id;
         try
         {
             ap_id = GetLocationApId(id);
@@ -332,7 +332,7 @@ public static class ArchipelagoManager
 
     public static bool CollectLocationByName(string name)
     {
-        int ap_id;
+        long ap_id;
         try
         {
             ap_id = GetLocationApId(name);

--- a/GatorRando/ArchipelagoManager.cs
+++ b/GatorRando/ArchipelagoManager.cs
@@ -42,7 +42,7 @@ public static class ArchipelagoManager
     public static int GetItemUnlockCount(string itemName) =>
         Session.Items.AllItemsReceived.Where(itemInfo => itemInfo.ItemId == GetItemApId(itemName)).Count();
 
-    public static bool CheckIfAPLocationInSave(long id) => Util.FindKeysByPrefix(location_key_prefix).Contains(id.ToString());
+    public static bool CheckIfAPLocationInSave(long id) => Util.FindBoolKeysByPrefix(location_key_prefix).Contains(id.ToString());
 
     public static bool IsFullyConnected
     {
@@ -141,7 +141,7 @@ public static class ArchipelagoManager
         static (string server, int port) GetServer()
         {
             string serverPrefix = "server address:port";
-            string serverWithPrefix = Util.FindKeyByPrefix(serverPrefix);
+            string serverWithPrefix = Util.FindIntKeyByPrefix(serverPrefix);
             if (serverWithPrefix == "")
             {
                 throw new Exception("No server address has been set in the Settings Menu");
@@ -161,7 +161,7 @@ public static class ArchipelagoManager
         static string GetPassword()
         {
             string passwordPrefix = "password";
-            string passwordWithPrefix = Util.FindKeyByPrefix(passwordPrefix);
+            string passwordWithPrefix = Util.FindIntKeyByPrefix(passwordPrefix);
             if (passwordWithPrefix == "")
             {
                 return "";
@@ -179,10 +179,11 @@ public static class ArchipelagoManager
 
         static void SendLocallySavedLocations()
         {
-            foreach (long location in Util.FindKeysByPrefix(location_key_prefix).Select(long.Parse))
+            foreach (long location in Util.FindBoolKeysByPrefix(location_key_prefix).Select(long.Parse))
             {
                 if (!Session.Locations.AllLocationsChecked.Contains(location))
                 {
+                    Plugin.LogDebug("Collecting Saved Location: " + location.ToString());
                     CollectLocationByAPID(location);
                 }
             }
@@ -237,7 +238,7 @@ public static class ArchipelagoManager
             }
             else
             {
-                locationsCollected = Util.FindKeysByPrefix("AP ID ").Select(long.Parse);
+                locationsCollected = Util.FindBoolKeysByPrefix("AP ID ").Select(long.Parse);
             }
             foreach (long locationApId in locationsCollected)
             {

--- a/GatorRando/ArchipelagoManager.cs
+++ b/GatorRando/ArchipelagoManager.cs
@@ -128,11 +128,12 @@ public static class ArchipelagoManager
             Plugin.Instance.StartCoroutine(Util.RunAfterCoroutine(0.5f, () => IsFullyConnected, () =>
             {
                 postConnectAction();
-                ReceiveUnreceivedItems();
-                TriggerItemListeners();//trigger listener functions for *any* item we have, not just recently received ones
-                TriggerLocationListeners();//trigger listener functions for any location that is collected
-                AttachListeners();//hook up listener functions for future live updates
-                ScoutLocations();
+                SendLocallySavedLocations(); //send all locations that in the local save but are not in the server's record (in case of disconnection)
+                ReceiveUnreceivedItems(); //receive all new items from the AP server
+                TriggerItemListeners(); //trigger listener functions for *any* item we have, not just recently received ones
+                TriggerLocationListeners(); //trigger listener functions for any location that is collected
+                AttachListeners(); //hook up listener functions for future live updates
+                ScoutLocations(); //gather information on what items are at locations so that we can show notifications
             }));
         }
 
@@ -167,6 +168,17 @@ public static class ArchipelagoManager
             else
             {
                 return passwordWithPrefix.Remove(0, passwordPrefix.Length);
+            }
+        }
+
+        static void SendLocallySavedLocations()
+        {
+            foreach (long location in Util.FindKeysByPrefix("AP ID ").Select(long.Parse))
+            {
+                if (!Session.Locations.AllLocationsChecked.Contains(location))
+                {
+                    CollectLocationByAPID(location);
+                }
             }
         }
 

--- a/GatorRando/ArchipelagoManager.cs
+++ b/GatorRando/ArchipelagoManager.cs
@@ -341,8 +341,10 @@ public static class ArchipelagoManager
 
     public static void SendCompletion()
     {
-        var statusUpdatePacket = new StatusUpdatePacket();
-        statusUpdatePacket.Status = ArchipelagoClientState.ClientGoal;
+        var statusUpdatePacket = new StatusUpdatePacket
+        {
+            Status = ArchipelagoClientState.ClientGoal
+        };
         Session.Socket.SendPacket(statusUpdatePacket);
     }
 }

--- a/GatorRando/ArchipelagoManager.cs
+++ b/GatorRando/ArchipelagoManager.cs
@@ -224,14 +224,14 @@ public static class ArchipelagoManager
 
         static void TriggerLocationListeners()
         {
-            ReadOnlyCollection<long> locationsCollected;
+            IEnumerable<long> locationsCollected;
             if (LocationAutoCollect)
             {
                 locationsCollected = Session.Locations.AllLocationsChecked;
             }
             else
             {
-                locationsCollected = new ReadOnlyCollection<long>((List<long>)Util.FindKeysByPrefix("AP ID ").Select(long.Parse));
+                locationsCollected = Util.FindKeysByPrefix("AP ID ").Select(long.Parse);
             }
             foreach (long locationApId in locationsCollected)
             {

--- a/GatorRando/ArchipelagoManager.cs
+++ b/GatorRando/ArchipelagoManager.cs
@@ -292,6 +292,7 @@ public static class ArchipelagoManager
         try
         {
             ap_id = GetLocationApId(id);
+            GameData.g.Write("AP ID: " + ap_id, true);
         }
         catch (InvalidOperationException)
         {

--- a/GatorRando/UIMods/SettingInput.cs
+++ b/GatorRando/UIMods/SettingInput.cs
@@ -24,7 +24,7 @@ public class SettingInput : MonoBehaviour
 			}
 			else
 			{
-				string currentPrefixAndValue = Util.FindKeyByPrefix(this.key);
+				string currentPrefixAndValue = Util.FindIntKeyByPrefix(this.key);
 				if (currentPrefixAndValue != "")
 				{
 					this.inputfield.text = currentPrefixAndValue.Remove(0,this.key.Length);
@@ -64,7 +64,7 @@ public class SettingInput : MonoBehaviour
 			}
 			else
 			{
-				Util.RemoveKeysByPrefix(this.key);
+				Util.RemoveIntKeysByPrefix(this.key);
 				GameData.g.Write(this.key + this.inputfield.text, 0);
 			}
 		}

--- a/GatorRando/UIMods/SettingsMods.cs
+++ b/GatorRando/UIMods/SettingsMods.cs
@@ -57,6 +57,10 @@ static class SettingsMods
 
         // Add Disconnect to Back To Title button
         Util.GetByPath("Canvas/Pause Menu/Pause Content/Back to Title").GetComponent<Button>().onClick.AddListener(ArchipelagoManager.Disconnect);
+
+        // Add Toggle so that players can choose whether they want !collect-ed locations to count as checked or not
+        CreateSettingsToggle(9, "!collect counts as Checked", "if checked, locations that are !collect-ed by other seeds count as checked for advancing quests." +
+            "if unchecked, uses what locations as saved in the save file.");
     }
 
     private static void ReworkPlayerRename()
@@ -129,6 +133,24 @@ static class SettingsMods
         Button buttonButton = button.GetComponent<Button>();
         buttonButton.onClick.ObliteratePersistentListenerByIndex(0);
         buttonButton.onClick.AddListener(call);
+    }
+
+    private static void CreateSettingsToggle(int siblingIndex, string name, string description)
+    {
+        GameObject settingsMenu = Util.GetByPath("Canvas/Pause Menu/Settings/Viewport/Content");
+        GameObject aimToggle = Util.GetByPath("Canvas/Pause Menu/Settings/Viewport/Content/use movement to aim");
+        GameObject toggle = GameObject.Instantiate(aimToggle, settingsMenu.transform);
+        toggle.transform.SetSiblingIndex(siblingIndex);
+        toggle.name = name;
+        GameObject label = toggle.transform.Find("Label").gameObject;
+        Object.Destroy(label.GetComponent<MLText>());
+        Text labelText = label.GetComponent<Text>();
+        labelText.text = name.ToLower();
+        UIDescription descript = toggle.GetComponent<UIDescription>();
+        descript.document = null;
+        descript.descriptionText = description;
+        SettingToggle settingToggle = toggle.GetComponent<SettingToggle>();
+        settingToggle.key = name.ToLower();
     }
 
     private static void CreateSettingsHeader(int siblingIndex, string name)

--- a/GatorRando/UIMods/SettingsMods.cs
+++ b/GatorRando/UIMods/SettingsMods.cs
@@ -59,7 +59,7 @@ static class SettingsMods
         Util.GetByPath("Canvas/Pause Menu/Pause Content/Back to Title").GetComponent<Button>().onClick.AddListener(ArchipelagoManager.Disconnect);
 
         // Add Toggle so that players can choose whether they want !collect-ed locations to count as checked or not
-        CreateSettingsToggle(9, "!collect counts as Checked", "if checked, locations that are !collect-ed by other seeds count as checked for advancing quests." +
+        CreateSettingsToggle(8, "!collect counts as Checked", "set before connecting to server. if checked, locations that are !collect-ed by other seeds count as checked for advancing quests." +
             "if unchecked, uses what locations as saved in the save file.");
     }
 

--- a/GatorRando/Util.cs
+++ b/GatorRando/Util.cs
@@ -140,6 +140,20 @@ public static class Util
         return keys[0];
     }
 
+    public static List<string> FindKeysByPrefix(string prefix)
+    {
+        List<string> keys = [];
+        foreach (string key in GameData.g.gameSaveData.ints.Keys)
+        {
+            if (key.StartsWith(prefix))
+            {
+                keys.Add(key);
+            }
+        }
+        return keys;
+    }
+
+
     public static void RemoveKeysByPrefix(string prefix)
     {
         List<string> keys = [];

--- a/GatorRando/Util.cs
+++ b/GatorRando/Util.cs
@@ -119,7 +119,7 @@ public static class Util
         }
     }
 
-    public static string FindKeyByPrefix(string prefix)
+    public static string FindIntKeyByPrefix(string prefix)
     {
         List<string> keys = [];
         foreach (string key in GameData.g.gameSaveData.ints.Keys)
@@ -140,21 +140,21 @@ public static class Util
         return keys[0];
     }
 
-    public static List<string> FindKeysByPrefix(string prefix)
+    public static List<string> FindBoolKeysByPrefix(string prefix)
     {
         List<string> keys = [];
-        foreach (string key in GameData.g.gameSaveData.ints.Keys)
+        foreach (string key in GameData.g.gameSaveData.bools.Keys)
         {
             if (key.StartsWith(prefix))
             {
-                keys.Add(key);
+                keys.Add(key.Substring(prefix.Length));
             }
         }
         return keys;
     }
 
 
-    public static void RemoveKeysByPrefix(string prefix)
+    public static void RemoveIntKeysByPrefix(string prefix)
     {
         List<string> keys = [];
         foreach (string key in GameData.g.gameSaveData.ints.Keys)


### PR DESCRIPTION
Write the locations checked in game into the save data to prevent loss of checks due to disconnection or other server connection hiccups. Any locations checked in the save file will be checked server-side upon a successful "Connect to Server." Note that if you connect a finished AP save to a new world's slot, that could result in a release of checks. (You should not connect an old save to a new slot anyway and the number of items received would likely be higher client-side, resulting in no successful connection.)

Additionally, implement client-side authority on whether !collect-ed locations (due to another game finishing/being forfeited) affects in-game behavior (i.e. advancing quests where steps are checks that have been collected). Defaults to true (you don't have to redo checks that have been completed), but toggleable in the settings menu before connection.

This change is back-compatible with games started on prior versions; however, games started on prior versions should leave "!collect counts as checked" on (checkmark) because the save file will not contain data on locations checked prior to this change.

Resolves #43 