### PR TITLE
Improve Sprite Handling

### DIFF
--- a/GatorRando/Archipelago/ItemHandling.cs
+++ b/GatorRando/Archipelago/ItemHandling.cs
@@ -47,6 +47,10 @@ public static class ItemHandling
         }
         else
         {
+            if (itemName == "Broken Scooter Board")
+            {
+                itemName = "Shield_ScooterBoardGreen";
+            }
             return ArchipelagoManager.Session.Items.AllItemsReceived.Select(info => info.ItemId).Contains(GetItemApIdFromGatorName(itemName));
         }
     }

--- a/GatorRando/Data/LocationRules.json
+++ b/GatorRando/Data/LocationRules.json
@@ -1813,43 +1813,55 @@
         "location_id": 100000651,
         "region": "Big Island Breakables",
         "rule_json": {
-            "rule": "Or",
+            "rule": "And",
             "options": [],
             "children": [
                 {
-                    "rule": "HasGroup",
+                    "rule": "Or",
                     "options": [],
-                    "args": {
-                        "item_name_group": "Ranged",
-                        "count": 1
-                    }
-                },
-                {
-                    "rule": "Has",
-                    "options": [],
-                    "args": {
-                        "item_name": "Bracelet",
-                        "count": 1
-                    }
-                },
-                {
-                    "rule": "True_",
-                    "options": [
+                    "children": [
                         {
-                            "option": "worlds.lil_gator_game.options.LockPotsBehindItems",
-                            "value": 0,
-                            "operator": "eq"
+                            "rule": "HasGroup",
+                            "options": [],
+                            "args": {
+                                "item_name_group": "Ranged",
+                                "count": 1
+                            }
+                        },
+                        {
+                            "rule": "Has",
+                            "options": [],
+                            "args": {
+                                "item_name": "Bracelet",
+                                "count": 1
+                            }
                         }
-                    ],
-                    "args": {}
+                    ]
                 },
                 {
-                    "rule": "Has",
+                    "rule": "Or",
                     "options": [],
-                    "args": {
-                        "item_name": "Sleep Mask",
-                        "count": 1
-                    }
+                    "children": [
+                        {
+                            "rule": "True_",
+                            "options": [
+                                {
+                                    "option": "worlds.lil_gator_game.options.LockPotsBehindItems",
+                                    "value": 0,
+                                    "operator": "eq"
+                                }
+                            ],
+                            "args": {}
+                        },
+                        {
+                            "rule": "Has",
+                            "options": [],
+                            "args": {
+                                "item_name": "Sleep Mask",
+                                "count": 1
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/GatorRando/Plugin.cs
+++ b/GatorRando/Plugin.cs
@@ -48,6 +48,7 @@ public class Plugin : BaseUnityPlugin
             }
             else if (scene.name == "Island")
             {
+                SpriteHandler.LoadSprites();
                 ApplyQuestEdits();
                 ApplyUIEdits();
                 BalloonMods.EditBalloonStamina();

--- a/GatorRando/UIMods/BubbleManager.cs
+++ b/GatorRando/UIMods/BubbleManager.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using UnityEngine;
 
 namespace GatorRando.UIMods;
 
@@ -16,7 +13,7 @@ public static class BubbleManager
     private static TimeSpan timeBetweenBubbles = TimeSpan.FromSeconds(3);
     private static readonly int maxItemMessages = 5;
     private static string lastMessage = "";
-    private static TimeSpan lastMessageExpiration = TimeSpan.FromSeconds(10);
+    private static TimeSpan lastMessageExpiration = TimeSpan.FromSeconds(6);
 
     public enum BubbleType
     {
@@ -41,6 +38,7 @@ public static class BubbleManager
         {
             // Only queue if not a duplicate message
             GetBubbleQueue(bubbleType).Enqueue(dialogueString);
+            lastMessage = dialogueString;
         }
     } 
 

--- a/GatorRando/UIMods/BubbleManager.cs
+++ b/GatorRando/UIMods/BubbleManager.cs
@@ -15,6 +15,8 @@ public static class BubbleManager
     private static DateTime lastBubbleTime = DateTime.UtcNow;
     private static TimeSpan timeBetweenBubbles = TimeSpan.FromSeconds(3);
     private static readonly int maxItemMessages = 5;
+    private static string lastMessage = "";
+    private static TimeSpan lastMessageExpiration = TimeSpan.FromSeconds(10);
 
     public enum BubbleType
     {
@@ -33,7 +35,14 @@ public static class BubbleManager
         _ => throw new Exception("Somehow we have an invalid BubbleType"),
     };
 
-    public static void QueueBubble(string dialogueString, BubbleType bubbleType) => GetBubbleQueue(bubbleType).Enqueue(dialogueString);
+    public static void QueueBubble(string dialogueString, BubbleType bubbleType)
+    {
+        if (dialogueString != lastMessage)
+        {
+            // Only queue if not a duplicate message
+            GetBubbleQueue(bubbleType).Enqueue(dialogueString);
+        }
+    } 
 
     private static void DequeueBubble(BubbleType bubbleType)
     {
@@ -95,6 +104,11 @@ public static class BubbleManager
                     lastBubbleTime = DateTime.UtcNow;
                 }
             }
+        }
+        if (DateTime.UtcNow - lastBubbleTime > lastMessageExpiration)
+        {
+            // Reset last message after time has elasped
+            lastMessage = "";
         }
     }
 }

--- a/GatorRando/UIMods/SpriteHandler.cs
+++ b/GatorRando/UIMods/SpriteHandler.cs
@@ -73,12 +73,6 @@ public static class SpriteHandler
         {"Sword_Stick", "Assets/UI/Images/Item Sprites/Itemsprite_sword_stick.png"},
         {"Sword_Wood", "Assets/UI/Images/Item Sprites/Itemsprite_sword_wooden.png"},
         {"Sword_Wrench", "Assets/UI/Images/Item Sprites/Itemsprite_sword_wrench.png"},
-
-        // LOOKING FOR GatorMewhenyouaremyfriend
-        // Itemsprite_quest_icecream
-        // Itemsprite_quest_clippings
-        // Itemsprite_quest_bucketfull
-        // Magic Ore
     };
     private static readonly Dictionary<string, AddedTexture> newSpriteInformation = new()
     {
@@ -100,7 +94,8 @@ public static class SpriteHandler
         {"ICE CREAM", "Itemsprite_quest_icecream"},
         {"CLIPPINGS", "Itemsprite_quest_clippings"},
         {"WATER", "Itemsprite_quest_bucketfull"},
-        {"BEACH ROCK", "Itemsprite_quest_clippings"},
+        {"BEACH ROCK", "Itemsprite_quest_cavemanrock"},
+        {"HALF A CHEESE SANDWICH", "Itemsprite_quest_halfacheesesandwich"},
     };
 
     public readonly struct AddedTexture(string path, int width, int height)
@@ -131,36 +126,42 @@ public static class SpriteHandler
 
     private static void LoadAssetSprites()
     {
-        foreach (string spriteName in existingSpritePaths.Keys)
+        if (loadedAssetSprites.Count == 0)
         {
-            loadedAssetSprites[spriteName] = Addressables.LoadAssetAsync<Sprite>(existingSpritePaths[spriteName]).WaitForCompletion();
+            foreach (string spriteName in existingSpritePaths.Keys)
+            {
+                loadedAssetSprites[spriteName] = Addressables.LoadAssetAsync<Sprite>(existingSpritePaths[spriteName]).WaitForCompletion();
+            }
         }
     }
 
     private static void DuplicateNonAssetLoadSprites()
     {
-        builtinSprites ??= Resources.FindObjectsOfTypeAll<Sprite>();
-        foreach (string itemName in spritesToDuplicateInformation.Keys)
+        if (duplicatedSprites.Count == 0)
         {
-            Sprite existingSprite;
-            try
+            builtinSprites ??= Resources.FindObjectsOfTypeAll<Sprite>();
+            foreach (string itemName in spritesToDuplicateInformation.Keys)
             {
-                existingSprite = builtinSprites.First(sprite => sprite.name == spritesToDuplicateInformation[itemName]);
-            }
-            catch (InvalidOperationException)
-            {
-                Plugin.LogWarn("No sprite found, storing placeholder!");
-                existingSprite = Util.FindItemObjectByName("Placeholder").sprite;
-            }
+                Sprite existingSprite;
+                try
+                {
+                    existingSprite = builtinSprites.First(sprite => sprite.name == spritesToDuplicateInformation[itemName]);
+                }
+                catch (InvalidOperationException)
+                {
+                    Plugin.LogWarn("No sprite found, storing placeholder!");
+                    existingSprite = Util.FindItemObjectByName("Placeholder").sprite;
+                }
 
-            duplicatedSprites[itemName] = DuplicateSprite(existingSprite.texture);
+                duplicatedSprites[itemName] = DuplicateSprite(existingSprite.texture);
+            }
         }
     }
 
     private static Sprite DuplicateSprite(Texture2D originalTexture)
     {
-        Texture2D copyTexture = new(originalTexture.width, originalTexture.height);
-        copyTexture.LoadRawTextureData(originalTexture.GetRawTextureData());
+        Texture2D copyTexture = new(originalTexture.width, originalTexture.height, textureFormat: originalTexture.format, mipCount: originalTexture.mipmapCount, linear: false);
+        Graphics.CopyTexture(originalTexture, copyTexture);
         return Sprite.Create(copyTexture, new Rect(0, 0, originalTexture.width, originalTexture.height), new Vector2(0.5f, 0.5f));
     }
 

--- a/GatorRando/UIMods/SpriteHandler.cs
+++ b/GatorRando/UIMods/SpriteHandler.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using System.Linq;
+using System;
 
 namespace GatorRando.UIMods;
 
@@ -11,70 +12,73 @@ public static class SpriteHandler
 {
     private static Sprite[] builtinSprites;
     private static readonly List<Sprite> newSprites = [];
+    private static readonly Dictionary<string, Sprite> loadedAssetSprites = [];
+    private static readonly Dictionary<string, Sprite> duplicatedSprites = [];
     private static readonly Dictionary<string, string> existingSpritePaths = new()
     {
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_core_bracelet_blue.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_core_bracelet_magenta.png"},
+        {"Bracelet", "Assets/UI/Images/Item Sprites/Itemsprite_core_bracelet_blue.png"},
+        {"Bracelet Magenta", "Assets/UI/Images/Item Sprites/Itemsprite_core_bracelet_magenta.png"},
         {"Craft Stuff", "Assets/UI/Images/Item Sprites/Itemsprite_core_crafting.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_core_purple.png"},
+        {"Bracelet Purple", "Assets/UI/Images/Item Sprites/Itemsprite_core_purple.png"},
         {"Shirt", "Assets/UI/Images/Item Sprites/Itemsprite_core_shirt.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_core_yellow.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_hat_basic.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_hat_beret.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_hat_bucket.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_hat_cowboy.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_hat_detective.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_hat_frills.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_hat_ninja.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_hat_princess.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_hat_skate.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_hat_slime.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_hat_spacehelmet.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_hat_vampire.png"},
+        {"Bracelet Yellow", "Assets/UI/Images/Item Sprites/Itemsprite_core_yellow.png"},
+        {"Hat_Basic", "Assets/UI/Images/Item Sprites/Itemsprite_hat_basic.png"},
+        {"Hat_Beret", "Assets/UI/Images/Item Sprites/Itemsprite_hat_beret.png"},
+        {"Hat_Bucket", "Assets/UI/Images/Item Sprites/Itemsprite_hat_bucket.png"},
+        {"Hat_Western", "Assets/UI/Images/Item Sprites/Itemsprite_hat_cowboy.png"},
+        {"Hat_DetectiveCowl", "Assets/UI/Images/Item Sprites/Itemsprite_hat_detective.png"},
+        {"Hat_Frills", "Assets/UI/Images/Item Sprites/Itemsprite_hat_frills.png"},
+        {"Hat_Ninja", "Assets/UI/Images/Item Sprites/Itemsprite_hat_ninja.png"},
+        {"Hat_Princess", "Assets/UI/Images/Item Sprites/Itemsprite_hat_princess.png"},
+        {"Hat_SkateHelmet", "Assets/UI/Images/Item Sprites/Itemsprite_hat_skate.png"},
+        {"Hat_Slime", "Assets/UI/Images/Item Sprites/Itemsprite_hat_slime.png"},
+        {"Hat_Space", "Assets/UI/Images/Item Sprites/Itemsprite_hat_spacehelmet.png"},
+        {"Hat_Vampire", "Assets/UI/Images/Item Sprites/Itemsprite_hat_vampire.png"},
         {"POT?", "Assets/UI/Images/Item Sprites/Itemsprite_quest_pot.png"},
         {"QuestItem_Retainer", "Assets/UI/Images/Item Sprites/Itemsprite_quest_retainer.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_shield_bigleaf.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_shield_chessboard.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_shield_innertube.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_shield_martin.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_shield_palette.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_shield_platter.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_shield_potlid.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_shield_scooterboardblue.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_shield_scooterboardgreen.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_shield_skateboard.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_shield_tower.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_shield_trampoline.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_shield_trashcanlid.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_special_balloon.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_special_bowlingbomb.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_special_camera.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_special_gum.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_special_megaphone.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_special_paintblaster.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_special_paperstars.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_special_ragdoll.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_special_rock.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_special_spaceblaster.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_special_stickyhand.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_special_textjill.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_sword_cavemanhammer.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_sword_grabber.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_sword_lasersword.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_sword_net.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_sword_nunchucks.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_sword_paintbrush.png"},
-        {"Thrown_Pencil", "Assets/UI/Images/Item Sprites/Itemsprite_sword_pencil.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_sword_princesswand.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_sword_spear.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_sword_stick.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_sword_wooden.png"},
-        // {"ohai", "Assets/UI/Images/Item Sprites/Itemsprite_sword_wrench.png"},
+        {"Shield_Leaf", "Assets/UI/Images/Item Sprites/Itemsprite_shield_bigleaf.png"},
+        {"Shield_Chessboard", "Assets/UI/Images/Item Sprites/Itemsprite_shield_chessboard.png"},
+        {"Shield_Tube", "Assets/UI/Images/Item Sprites/Itemsprite_shield_innertube.png"},
+        {"Shield_Martin", "Assets/UI/Images/Item Sprites/Itemsprite_shield_martin.png"},
+        {"Shield_Palette", "Assets/UI/Images/Item Sprites/Itemsprite_shield_palette.png"},
+        {"Shield_Platter", "Assets/UI/Images/Item Sprites/Itemsprite_shield_platter.png"},
+        {"Shield_PotLid", "Assets/UI/Images/Item Sprites/Itemsprite_shield_potlid.png"},
+        {"Shield_ScooterBoardBlue", "Assets/UI/Images/Item Sprites/Itemsprite_shield_scooterboardblue.png"},
+        {"Shield_ScooterBoardGreen", "Assets/UI/Images/Item Sprites/Itemsprite_shield_scooterboardgreen.png"},
+        {"Shield_Skateboard", "Assets/UI/Images/Item Sprites/Itemsprite_shield_skateboard.png"},
+        {"Shield_TowerShield", "Assets/UI/Images/Item Sprites/Itemsprite_shield_tower.png"},
+        {"Shield_Stretch", "Assets/UI/Images/Item Sprites/Itemsprite_shield_trampoline.png"},
+        {"Shield_TrashCanLid", "Assets/UI/Images/Item Sprites/Itemsprite_shield_trashcanlid.png"},
+        {"Item_Balloon", "Assets/UI/Images/Item Sprites/Itemsprite_special_balloon.png"},
+        {"Item_Bomb", "Assets/UI/Images/Item Sprites/Itemsprite_special_bowlingbomb.png"},
+        {"Item_Camera", "Assets/UI/Images/Item Sprites/Itemsprite_special_camera.png"},
+        {"Item_Gum", "Assets/UI/Images/Item Sprites/Itemsprite_special_gum.png"},
+        {"Item_SearchNPCs", "Assets/UI/Images/Item Sprites/Itemsprite_special_megaphone.png"},
+        {"Item_PaintGun", "Assets/UI/Images/Item Sprites/Itemsprite_special_paintblaster.png"},
+        {"Item_Shuriken", "Assets/UI/Images/Item Sprites/Itemsprite_special_paperstars.png"},
+        {"Item_Ragdoll", "Assets/UI/Images/Item Sprites/Itemsprite_special_ragdoll.png"},
+        {"Rock", "Assets/UI/Images/Item Sprites/Itemsprite_special_rock.png"},
+        {"Item_SpaceGun", "Assets/UI/Images/Item Sprites/Itemsprite_special_spaceblaster.png"},
+        {"Item_StickyHand", "Assets/UI/Images/Item Sprites/Itemsprite_special_stickyhand.png"},
+        {"Item_SearchObjects", "Assets/UI/Images/Item Sprites/Itemsprite_special_textjill.png"},
+        {"Sword_RockHammer", "Assets/UI/Images/Item Sprites/Itemsprite_sword_cavemanhammer.png"},
+        {"Sword_Grabby", "Assets/UI/Images/Item Sprites/Itemsprite_sword_grabber.png"},
+        {"Sword_Laser", "Assets/UI/Images/Item Sprites/Itemsprite_sword_lasersword.png"},
+        {"Sword_Net", "Assets/UI/Images/Item Sprites/Itemsprite_sword_net.png"},
+        {"Sword_Nunchucks", "Assets/UI/Images/Item Sprites/Itemsprite_sword_nunchucks.png"},
+        {"Sword_Paintbrush", "Assets/UI/Images/Item Sprites/Itemsprite_sword_paintbrush.png"},
+        {"Sword_Pencil", "Assets/UI/Images/Item Sprites/Itemsprite_sword_pencil.png"},
+        {"Sword_Wand", "Assets/UI/Images/Item Sprites/Itemsprite_sword_princesswand.png"},
+        {"Sword_CBSpear", "Assets/UI/Images/Item Sprites/Itemsprite_sword_spear.png"},
+        {"Sword_Stick", "Assets/UI/Images/Item Sprites/Itemsprite_sword_stick.png"},
+        {"Sword_Wood", "Assets/UI/Images/Item Sprites/Itemsprite_sword_wooden.png"},
+        {"Sword_Wrench", "Assets/UI/Images/Item Sprites/Itemsprite_sword_wrench.png"},
 
         // LOOKING FOR GatorMewhenyouaremyfriend
         // Itemsprite_quest_icecream
         // Itemsprite_quest_clippings
         // Itemsprite_quest_bucketfull
+        // Magic Ore
     };
     private static readonly Dictionary<string, AddedTexture> newSpriteInformation = new()
     {
@@ -88,6 +92,15 @@ public static class SpriteHandler
         {"Archipelago", new AddedTexture("GatorRando.Sprites.archipelago_sticker_style.png", 200, 200)},
         {"Flag", new AddedTexture("GatorRando.Sprites.checkered_flag.png", 200, 200)},
         {"Socks", new AddedTexture("GatorRando.Sprites.giant_socks.png", 200, 200)},
+    };
+
+    private static readonly Dictionary<string, string> spritesToDuplicateInformation = new()
+    {
+        {"Friend", "GatorMewhenyouaremyfriend"},
+        {"ICE CREAM", "Itemsprite_quest_icecream"},
+        {"CLIPPINGS", "Itemsprite_quest_clippings"},
+        {"WATER", "Itemsprite_quest_bucketfull"},
+        {"BEACH ROCK", "Itemsprite_quest_clippings"},
     };
 
     public readonly struct AddedTexture(string path, int width, int height)
@@ -109,8 +122,48 @@ public static class SpriteHandler
         }
         return texture2D;
     }
-    
-    //TODO Retrieve Sprites in a way that does not result in them becoming unloaded
+
+    public static void LoadSprites()
+    {
+        LoadAssetSprites();
+        DuplicateNonAssetLoadSprites();
+    }
+
+    private static void LoadAssetSprites()
+    {
+        foreach (string spriteName in existingSpritePaths.Keys)
+        {
+            loadedAssetSprites[spriteName] = Addressables.LoadAssetAsync<Sprite>(existingSpritePaths[spriteName]).WaitForCompletion();
+        }
+    }
+
+    private static void DuplicateNonAssetLoadSprites()
+    {
+        builtinSprites ??= Resources.FindObjectsOfTypeAll<Sprite>();
+        foreach (string itemName in spritesToDuplicateInformation.Keys)
+        {
+            Sprite existingSprite;
+            try
+            {
+                existingSprite = builtinSprites.First(sprite => sprite.name == spritesToDuplicateInformation[itemName]);
+            }
+            catch (InvalidOperationException)
+            {
+                Plugin.LogWarn("No sprite found, storing placeholder!");
+                existingSprite = Util.FindItemObjectByName("Placeholder").sprite;
+            }
+
+            duplicatedSprites[itemName] = DuplicateSprite(existingSprite.texture);
+        }
+    }
+
+    private static Sprite DuplicateSprite(Texture2D originalTexture)
+    {
+        Texture2D copyTexture = new(originalTexture.width, originalTexture.height);
+        copyTexture.LoadRawTextureData(originalTexture.GetRawTextureData());
+        return Sprite.Create(copyTexture, new Rect(0, 0, originalTexture.width, originalTexture.height), new Vector2(0.5f, 0.5f));
+    }
+
     public static Sprite GetSpriteForItem(string name)
     {
         // Plugin.LogDebug($"Looking for sprite for {name}");
@@ -137,28 +190,25 @@ public static class SpriteHandler
             {
                 name = "Craft Stuff";
             }
-            // if (existingSpritePaths.ContainsKey(name))
-            // {
-            //     return Addressables.LoadAssetAsync<Sprite>(existingSpritePaths[name]);
-            // } 
-
-            // Plugin.LogDebug($"Loading sprite from game itself");
-            ItemObject itemObject = Util.FindItemObjectByName(name);
-            if (itemObject != null)
+            else if (name.Contains("Friend"))
             {
-                return itemObject.sprite;
+                name = "Friend";
+            }
+            else if (name.Contains("Thrown_Pencil"))
+            {
+                name = "Sword_Pencil";
+            }
+
+            if (spritesToDuplicateInformation.ContainsKey(name))
+            {
+                return duplicatedSprites[name];
+            }
+            else if (existingSpritePaths.ContainsKey(name))
+            {
+                return loadedAssetSprites[name];
             }
             else
             {
-                builtinSprites ??= Resources.FindObjectsOfTypeAll<Sprite>();
-                if (name.Contains("Craft Stuff"))
-                {
-                    return builtinSprites.First(sprite => sprite.name == "Itemsprite_core_crafting");
-                }
-                else if (name.Contains("Friend"))
-                {
-                    return builtinSprites.First(sprite => sprite.name == "GatorMewhenyouaremyfriend");
-                }
                 Plugin.LogWarn("No sprite found, using placeholder!");
                 return Util.FindItemObjectByName("Placeholder").sprite; // Should not appear
             }

--- a/GatorRando/patches/UISwapItemsMenuPatch.cs
+++ b/GatorRando/patches/UISwapItemsMenuPatch.cs
@@ -17,9 +17,15 @@ static class UISwapItemsMenuPatch
 
         foreach (ItemObject item in QuestItems.QuestItemObjects)
         {
-            if (item.name == "Archipelago")
+            if (item.name == "Broken Scooter Board")
             {
                 questItemsReceived.Add(item);
+            }
+            else if (item.name == "Archipelago")
+            {
+                //TODO figure out replacement for this item vis-a-vie scrolling
+                questItemsReceived.Add(item);
+                item.IsUnlocked = true;
             }
             else if (item.name != "Thrown_Pencil_2" && item.name != "Thrown_Pencil_3" && ItemHandling.IsItemUnlocked(item.name))
             {

--- a/GatorRando/questMods/QuestItems.cs
+++ b/GatorRando/questMods/QuestItems.cs
@@ -12,35 +12,39 @@ static class QuestItems
     {
         if (QuestItemObjects.Count == 0)
         {
-            QuestItemObjects.Add(Util.FindItemObjectByName("QuestItem_Retainer"));
+            QuestItemObjects.Add(Util.GenerateItemObject("Shirt", SpriteHandler.GetSpriteForItem("Shirt")));
+            QuestItemObjects.Add(Util.GenerateItemObject("QuestItem_Retainer", SpriteHandler.GetSpriteForItem("QuestItem_Retainer")));
+            QuestItemObjects.Add(Util.GenerateItemObject("Broken Scooter Board", SpriteHandler.GetSpriteForItem("Shield_ScooterBoardGreen")));
 
-            DSItem rock = Util.GetByPath("West (Forest)/Prep Quest/Subquests/Engineer/Rock Get Sequence").GetComponent<DSItem>();
-            QuestItemObjects.Add(Util.GenerateItemObject("BEACH ROCK", rock.itemSprite));
+            // QuestItemObjects.Add(Util.FindItemObjectByName("QuestItem_Retainer"));
 
-            DSItem cheese_sandwich = Util.GetByPath("West (Forest)/Prep Quest/Subquests/Economist/Loot Get Sequence").GetComponent<DSItem>();
-            QuestItemObjects.Add(Util.GenerateItemObject("HALF A CHEESE SANDWICH", cheese_sandwich.itemSprite));
+            // DSItem rock = Util.GetByPath("West (Forest)/Prep Quest/Subquests/Engineer/Rock Get Sequence").GetComponent<DSItem>();
+            QuestItemObjects.Add(Util.GenerateItemObject("BEACH ROCK", SpriteHandler.GetSpriteForItem("BEACH ROCK")));
 
-            DSItem pot = Util.GetByPath("NorthWest (Tutorial Island)/Act 1/Quests/Martin Quest/Get Pot Lid").GetComponent<DSItem>();
-            QuestItemObjects.Add(Util.GenerateItemObject("POT?", pot.itemSprite));
+            // DSItem cheese_sandwich = Util.GetByPath("West (Forest)/Prep Quest/Subquests/Economist/Loot Get Sequence").GetComponent<DSItem>();
+            QuestItemObjects.Add(Util.GenerateItemObject("HALF A CHEESE SANDWICH", SpriteHandler.GetSpriteForItem("HALF A CHEESE SANDWICH")));
 
-            DSItem iceCream = Util.GetByPath("North (Mountain)/Theatre Quest/Subquests/Vampire/Get Ice Cream").GetComponent<DSItem>();
-            QuestItemObjects.Add(Util.GenerateItemObject("ICE CREAM", iceCream.itemSprite));
+            // DSItem pot = Util.GetByPath("NorthWest (Tutorial Island)/Act 1/Quests/Martin Quest/Get Pot Lid").GetComponent<DSItem>();
+            QuestItemObjects.Add(Util.GenerateItemObject("POT?", SpriteHandler.GetSpriteForItem("POT?")));
 
-            DSItem clippings = Util.GetByPath("East (Creeklands)/Cool Kids Quest/Subquests/Boar Quest/Got Enough Grass Sequence").GetComponent<DSItem>();
-            QuestItemObjects.Add(Util.GenerateItemObject("CLIPPINGS", clippings.itemSprite));
+            // DSItem iceCream = Util.GetByPath("North (Mountain)/Theatre Quest/Subquests/Vampire/Get Ice Cream").GetComponent<DSItem>();
+            QuestItemObjects.Add(Util.GenerateItemObject("ICE CREAM", SpriteHandler.GetSpriteForItem("ICE CREAM")));
 
-            DSItem waterItem = Util.GetByPath("East (Creeklands)/Cool Kids Quest/Subquests/Boar Quest/Got Enough Water Sequence").GetComponent<DSItem>();
-            QuestItemObjects.Add(Util.GenerateItemObject("WATER", waterItem.itemSprite));
+            // DSItem clippings = Util.GetByPath("East (Creeklands)/Cool Kids Quest/Subquests/Boar Quest/Got Enough Grass Sequence").GetComponent<DSItem>();
+            QuestItemObjects.Add(Util.GenerateItemObject("CLIPPINGS", SpriteHandler.GetSpriteForItem("CLIPPINGS")));
 
-            ItemObject pencil = Util.FindItemObjectByName("Sword_Pencil");
-            QuestItemObjects.Add(Util.GenerateItemObject("Thrown_Pencil", pencil.sprite));
-            QuestItemObjects.Add(Util.GenerateItemObject("Thrown_Pencil_2", pencil.sprite));
-            QuestItemObjects.Add(Util.GenerateItemObject("Thrown_Pencil_3", pencil.sprite));
+            // DSItem waterItem = Util.GetByPath("East (Creeklands)/Cool Kids Quest/Subquests/Boar Quest/Got Enough Water Sequence").GetComponent<DSItem>();
+            QuestItemObjects.Add(Util.GenerateItemObject("WATER", SpriteHandler.GetSpriteForItem("WATER")));
 
-            // Sprite pencil = SpriteHandler.GetSpriteForItem("Thrown_Pencil");
-            // QuestItemObjects.Add(Util.GenerateItemObject("Thrown_Pencil", pencil));
-            // QuestItemObjects.Add(Util.GenerateItemObject("Thrown_Pencil_2", pencil));
-            // QuestItemObjects.Add(Util.GenerateItemObject("Thrown_Pencil_3", pencil));
+            // ItemObject pencil = Util.FindItemObjectByName("Sword_Pencil");
+            // QuestItemObjects.Add(Util.GenerateItemObject("Thrown_Pencil", pencil.sprite));
+            // QuestItemObjects.Add(Util.GenerateItemObject("Thrown_Pencil_2", pencil.sprite));
+            // QuestItemObjects.Add(Util.GenerateItemObject("Thrown_Pencil_3", pencil.sprite));
+
+            Sprite pencil = SpriteHandler.GetSpriteForItem("Thrown_Pencil");
+            QuestItemObjects.Add(Util.GenerateItemObject("Thrown_Pencil", pencil));
+            QuestItemObjects.Add(Util.GenerateItemObject("Thrown_Pencil_2", pencil));
+            QuestItemObjects.Add(Util.GenerateItemObject("Thrown_Pencil_3", pencil));
 
             QuestItemObjects.Add(Util.GenerateItemObject("Key", SpriteHandler.GetSpriteForItem("Key")));
             QuestItemObjects.Add(Util.GenerateItemObject("Flag", SpriteHandler.GetSpriteForItem("Flag")));
@@ -52,11 +56,7 @@ static class QuestItems
 
             QuestItemObjects.Add(Util.GenerateItemObject("Archipelago", SpriteHandler.GetSpriteForItem("Archipelago")));
 
-            // QuestItemObjects.Add(Util.GenerateItemObject("Glider", SpriteHandler.GetSpriteForItem("Glider")));
-            // QuestItemObjects.Add(Util.GenerateItemObject("QuestItem_Retainer", SpriteHandler.GetSpriteForItem("QuestItem_Retainer")));
-            // QuestItemObjects.Add(Util.GenerateItemObject("POT?", SpriteHandler.GetSpriteForItem("POT?")));
-
-            //TODO: Retrieve/Store sprites in a way that does not result in them unloading
+            
         }
     }
 }


### PR DESCRIPTION
Improve sprite handling by directly loading assets into sprites where possible and duplicating textures where asset loading is not available. By holding onto references to these sprites and textures in the mod, we prevent deloading of sprites during transitions, and thus issues with (a) crashing due to sprite not found and (b) white squares on the quest item inventory screen should be fixed.

Also, minor improvements to the Bubble Manager and a rules bug fix.

Closes #75, Closes #71, Closes #58, Closes #15