### PR TITLE
Clean Up Pass

### DIFF
--- a/GatorRando/Archipelago/ItemHandling.cs
+++ b/GatorRando/Archipelago/ItemHandling.cs
@@ -73,8 +73,8 @@ public static class ItemHandling
         {
             ReceiveItem(queuedItem.item, queuedItem.sendingPlayerName);
             LocationAccessibilty.UpdateAccessibleLocations();
-            var lastIndex = GameData.g.ReadInt("LastAPItemIndex", 0);
-            GameData.g.Write("LastAPItemIndex", lastIndex + 1);
+            var lastIndex = GameData.g.ReadInt(SaveManager.apItemIndexKey, 0);
+            GameData.g.Write(SaveManager.apItemIndexKey, lastIndex + 1);
         }
     }
 

--- a/GatorRando/Archipelago/SaveManager.cs
+++ b/GatorRando/Archipelago/SaveManager.cs
@@ -16,6 +16,7 @@ public static class SaveManager
     public static readonly string slotNameString = "Slot Name";
     public static readonly string serverString = "Server Address:Port";
     public static readonly string passwordString = "Password";
+    public static readonly string apItemIndexKey = "LastAPItemIndex";
 
     private static string CurrentSavePath()
     {
@@ -162,5 +163,23 @@ public static class SaveManager
     public static void ForceSave()
     {
         GameData.g.WriteToDisk(false);
+    }
+
+    public static bool CheckIfSaveAheadOfServer(int index)
+    {
+        ArchipelagoData tempServerData = JsonConvert.DeserializeObject<ArchipelagoData>(File.ReadAllText(apServerDataPaths[index]));
+        if (tempServerData.Index > ConnectionManager.ItemsReceived().Count)
+        {
+            return true; // Saved server data is ahead of the items received count
+        }
+        GameSaveData tempGameSaveData = FileUtil.ReadSaveData(index);
+        if (tempGameSaveData.ints.TryGetValue(apItemIndexKey, out int savedItemIndex))
+        {
+            if (savedItemIndex > ConnectionManager.ItemsReceived().Count)
+            {
+                return true; // Save file data is ahead of the item received count
+            }
+        }
+        return false; // Saves are not ahead of server
     }
 }

--- a/GatorRando/Archipelago/StateManager.cs
+++ b/GatorRando/Archipelago/StateManager.cs
@@ -1,6 +1,8 @@
+using System.Collections;
 using GatorRando.PrefabMods;
 using GatorRando.QuestMods;
 using GatorRando.UIMods;
+using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace GatorRando.Archipelago;
@@ -42,7 +44,8 @@ public static class StateManager
         }
         else if (scene.name == "Island")
         {
-            SetupLoadedGame();
+            UIMenus.u.SetGameplayState(false, true);
+            Plugin.Instance.StartCoroutine(SetupLoadedGame());
         }
     }
 
@@ -169,12 +172,12 @@ public static class StateManager
         return false;
     }
 
-    public static void SetupLoadedGame()
+    public static IEnumerator SetupLoadedGame()
     {
+        yield return new WaitForSeconds(1);
         currentState = State.PlayingGameConnected;
         ConnectionManager.RegisterItemReceivedListener();
         SpriteHandler.LoadSprites();
-        QuestEditMod.ApplyQuestEdits();
         UIEditMod.ApplyUIEdits();
         BalloonMods.EditBalloonStamina();
         RockMods.EditRockLayer();
@@ -182,8 +185,10 @@ public static class StateManager
         ConnectionManager.ServerData.PopulateLocationLookupCache();
         LocationHandling.SendLocallySavedLocations();
         ConnectionManager.ReceiveUnreceivedItems();
+        QuestEditMod.ApplyQuestEdits();
         ItemHandling.TriggerItemListeners();
         LocationHandling.TriggerLocationListeners();
         LocationAccessibilty.UpdateAccessibleLocations();
+        UIMenus.u.SetGameplayState(true, true);
     }
 }

--- a/GatorRando/Archipelago/StateManager.cs
+++ b/GatorRando/Archipelago/StateManager.cs
@@ -158,9 +158,15 @@ public static class StateManager
         }
     }
 
-    public static void LoadGame()
+    public static bool LoadGame(int index)
     {
-        currentState = State.LoadingGame;
+        if (!SaveManager.CheckIfSaveAheadOfServer(index))
+        {
+            currentState = State.LoadingGame;
+            return true;
+        }
+        DisplayError("Error: The save file you tried to load is ahead of the server it is connected to. When starting a new room for the same seed, you need to start a new save file.");
+        return false;
     }
 
     public static void SetupLoadedGame()

--- a/GatorRando/Archipelago/StateManager.cs
+++ b/GatorRando/Archipelago/StateManager.cs
@@ -44,7 +44,7 @@ public static class StateManager
         }
         else if (scene.name == "Island")
         {
-            UIMenus.u.SetGameplayState(false, true);
+            UIMenus.u.SetGameplayState(false, true); // Disable player input
             Plugin.Instance.StartCoroutine(SetupLoadedGame());
         }
     }
@@ -174,7 +174,7 @@ public static class StateManager
 
     public static IEnumerator SetupLoadedGame()
     {
-        yield return new WaitForSeconds(1);
+        yield return new WaitForSeconds(Plugin.LoadDelay);
         currentState = State.PlayingGameConnected;
         ConnectionManager.RegisterItemReceivedListener();
         SpriteHandler.LoadSprites();

--- a/GatorRando/Data/LocationRules.json
+++ b/GatorRando/Data/LocationRules.json
@@ -6207,53 +6207,6 @@
                                 "item_name": "Bracelet",
                                 "count": 1
                             }
-                        },
-                        {
-                            "rule": "And",
-                            "options": [],
-                            "children": [
-                                {
-                                    "rule": "Or",
-                                    "options": [],
-                                    "children": [
-                                        {
-                                            "rule": "True_",
-                                            "options": [
-                                                {
-                                                    "option": "worlds.lil_gator_game.options.RequireShieldJump",
-                                                    "value": 1,
-                                                    "operator": "eq"
-                                                }
-                                            ],
-                                            "args": {}
-                                        },
-                                        {
-                                            "rule": "Has",
-                                            "options": [],
-                                            "args": {
-                                                "item_name": "Out of Logic Item",
-                                                "count": 1
-                                            }
-                                        }
-                                    ]
-                                },
-                                {
-                                    "rule": "HasGroup",
-                                    "options": [],
-                                    "args": {
-                                        "item_name_group": "Cardboard Destroyer",
-                                        "count": 1
-                                    }
-                                },
-                                {
-                                    "rule": "HasGroup",
-                                    "options": [],
-                                    "args": {
-                                        "item_name_group": "Shield",
-                                        "count": 1
-                                    }
-                                }
-                            ]
                         }
                     ]
                 },

--- a/GatorRando/ItemUtil.cs
+++ b/GatorRando/ItemUtil.cs
@@ -26,6 +26,10 @@ public static class ItemUtil
             UIMenus.craftNotification.LoadItems([itemObject]);
             return;
         }
+        if (item == "Glider")
+        {
+            PlayerItemManager.p.gliderItem.IsUnlocked = true;
+        }
         ItemManager.i.UnlockItem(item);
         PlayerItemManager.p.Refresh(); // Originally only for "Shirt" not usuable on receipt but should result in updated visual for bracelets
     }

--- a/GatorRando/Plugin.cs
+++ b/GatorRando/Plugin.cs
@@ -1,4 +1,5 @@
 using BepInEx;
+using BepInEx.Configuration;
 using GatorRando.Archipelago;
 using HarmonyLib;
 using UnityEngine.SceneManagement;
@@ -10,6 +11,9 @@ public class Plugin : BaseUnityPlugin
 {
     public static Plugin Instance;
 
+    private static ConfigEntry<float> _loadDelay;
+    public static float LoadDelay => _loadDelay.Value;
+
     private void Awake()
     {
         Instance = this;
@@ -17,6 +21,7 @@ public class Plugin : BaseUnityPlugin
         harmony.PatchAll(); // automatically patch based on harmony attributes
         ArchipelagoConsole.Awake();
         ArchipelagoConsole.LogMessage($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");
+        _loadDelay = Config.Bind("Settings", "LoadDelay", 1f, "The time the mod will wait after loading in before the mod will finish loading all quest mods. Increase this value if it appears that modications are being applied too soon.");
     }
 
     private void Update()

--- a/GatorRando/patches/ItemSearchNPCsPatch.cs
+++ b/GatorRando/patches/ItemSearchNPCsPatch.cs
@@ -46,7 +46,7 @@ static class ItemSearchNPCsPatch
             _ => throw new Exception("Invalid enum value for CheckfinderBehavior"),
         };
 
-        __result =  [.. sideQuestActors, .. filteredMainActors];
+        __result = [.. sideQuestActors, .. filteredMainActors];
 
         // foreach(DialogueActor actor in __result){
         //     Plugin.LogInfo("ID:" + actor.profile.id + ", Parent:" + actor.transform.parent.name);
@@ -55,7 +55,7 @@ static class ItemSearchNPCsPatch
 
     [HarmonyPostfix]
     [HarmonyPatch("IsValid")]
-    static void PostIsValid(DialogueActor item, ref bool __result)
+    static void PostIsValid(ItemSearchNPCs __instance, DialogueActor item, ref bool __result)
     {
         __result = __result && item.gameObject.activeInHierarchy;
         string gatorName = LocationAccessibilty.ConvertDAToGatorName(item);
@@ -64,9 +64,21 @@ static class ItemSearchNPCsPatch
         {
             "Tutorial Avery" => !checks.Select(LocationHandling.IsLocationCollected).All(b => b),
             "Tutorial Stick Jill" => !checks.Select(LocationHandling.IsLocationCollected).All(b => b),
-            "Tutorial End Jill" => !checks.Select(LocationHandling.IsLocationCollected).All(b => b),
+            "Tutorial End Jill" => HandleTutorialEndJill(__instance, checks),
             "Tutorial Martin" => !checks.Select(LocationHandling.IsLocationCollected).All(b => b),
             _ => __result,
         };
+    }
+
+    static bool HandleTutorialEndJill(ItemSearchNPCs thisItemSearchNPCs, string[] checks)
+    {
+        if (thisItemSearchNPCs.GetList().First(da => LocationAccessibilty.ConvertDAToGatorName(da) == "NPC_TutIsland_Duck").gameObject.activeInHierarchy)
+        {
+            return false;
+        }
+        else
+        {
+            return !checks.Select(LocationHandling.IsLocationCollected).All(b => b);
+        }
     }
 }

--- a/GatorRando/patches/SaveFileScreenPatch.cs
+++ b/GatorRando/patches/SaveFileScreenPatch.cs
@@ -8,18 +8,20 @@ static class SaveFileScreenPatch
 {
     [HarmonyPrefix]
     [HarmonyPatch(nameof(SaveFileScreen.PressSaveFileButton))]
-    static void PrePressSaveFileButton(SaveFileScreen __instance, int index)
+    static bool PrePressSaveFileButton(SaveFileScreen __instance, int index)
     {
         if (__instance.currentState == SaveFileScreen.State.Standard)
         {
             if (FileUtil.IsSaveFileStarted(index))
             {
-                StateManager.LoadGame();
+                return StateManager.LoadGame(index);
             }
             else
             {
                 StateManager.StartNewGame(index);
+                return true;
             }
         }
+        return true;
     }
 }

--- a/GatorRando/patches/UISwapItemsMenuPatch.cs
+++ b/GatorRando/patches/UISwapItemsMenuPatch.cs
@@ -17,14 +17,14 @@ static class UISwapItemsMenuPatch
 
         foreach (ItemObject item in QuestItems.QuestItemObjects)
         {
-            if (item.name == "Broken Scooter Board" && ItemHandling.IsItemUnlocked(item.name))
+            if (item.name == "Broken Scooter Board")
             {
                 if (ItemHandling.IsItemUnlocked(item.name, true))
                 {
                     questItemsReceived.Add(item);
                 }
             }
-            else if (item.name == "Glider" && ItemHandling.IsItemUnlocked(item.name, true))
+            else if (item.name == "Glider")
             {
                 if (ItemHandling.IsItemUnlocked(item.name, true))
                 {

--- a/GatorRando/questMods/CreditsMods.cs
+++ b/GatorRando/questMods/CreditsMods.cs
@@ -7,9 +7,9 @@ static class CreditsMods
 {
     public static void Edits()
     {
-        GameObject credits = Util.GetByPath("Center (Playground)/Story Sequences/Post-Credits");
-        DialogueSequencer creditsSeq = credits.GetComponent<DialogueSequencer>();
-        creditsSeq.beforeSequence.RemoveListener(ConnectionManager.SendGoal);
-        creditsSeq.beforeSequence.AddListener(ConnectionManager.SendGoal);
+        GameObject sisFlashbacks = Util.GetByPath("Center (Playground)/Story Sequences/Act3 Sis/Sis Flashbacks");
+        DialogueSequencer dialogueSeq = sisFlashbacks.GetComponent<DialogueSequencer>();
+        dialogueSeq.beforeSequence.RemoveListener(ConnectionManager.SendGoal);
+        dialogueSeq.beforeSequence.AddListener(ConnectionManager.SendGoal);
     }
 }

--- a/GatorRando/questMods/QuestEditMod.cs
+++ b/GatorRando/questMods/QuestEditMod.cs
@@ -30,7 +30,7 @@ public static class QuestEditMod
         //Allow Freeplay
         if (Options.GetOptionBool(Options.Option.StartWithFreeplay))
         {
-            TutorialQuestMods.StartWithFreeplay();
+            TutorialQuestMods.QueueStartWithFreeplay();
         } 
     }
 }

--- a/GatorRando/questMods/QuestItems.cs
+++ b/GatorRando/questMods/QuestItems.cs
@@ -1,5 +1,6 @@
 
 using System.Collections.Generic;
+using GatorRando.Archipelago;
 using GatorRando.UIMods;
 using UnityEngine;
 
@@ -12,7 +13,10 @@ static class QuestItems
     {
         if (QuestItemObjects.Count == 0)
         {
-            QuestItemObjects.Add(Util.GenerateItemObject("Glider", SpriteHandler.GetSpriteForItem("Shirt")));
+            ItemObject glider = Util.GenerateItemObject("Glider", SpriteHandler.GetSpriteForItem("Shirt"));
+            glider.IsUnlocked = ItemHandling.IsItemUnlocked("Shirt");
+            QuestItemObjects.Add(glider);
+            PlayerItemManager.p.gliderItem = glider; 
             QuestItemObjects.Add(Util.GenerateItemObject("QuestItem_Retainer", SpriteHandler.GetSpriteForItem("QuestItem_Retainer")));
             QuestItemObjects.Add(Util.GenerateItemObject("Broken Scooter Board", SpriteHandler.GetSpriteForItem("Shield_ScooterBoardGreen")));
 

--- a/GatorRando/questMods/TutorialQuestMods.cs
+++ b/GatorRando/questMods/TutorialQuestMods.cs
@@ -4,23 +4,35 @@ namespace GatorRando.QuestMods;
 
 static class TutorialQuestMods
 {
-
-    public static void StartWithFreeplay()
+    public static void QueueStartWithFreeplay()
     {
-        ReenableTutorialQuests();
         GameObject act1 = Util.GetByPath("NorthWest (Tutorial Island)/Act 1");
         QuestStates act1QuestStates = act1.GetComponent<QuestStates>();
-        act1QuestStates.states[0].onDeactivate.RemoveListener(AdvanceToEndOfTutorial);
-        act1QuestStates.states[0].onDeactivate.AddListener(AdvanceToEndOfTutorial);
-        if (act1QuestStates.StateID < 2)
+        act1QuestStates.onStateChange.RemoveListener(Act1QuestHandler);
+        act1QuestStates.onStateChange.AddListener(Act1QuestHandler);
+        if (act1QuestStates.StateID == 1)
         {
             AdvanceToEndOfTutorial();
         }
-        act1QuestStates.states[3].onActivate.RemoveListener(ReenableTutorialQuests);
-        act1QuestStates.states[3].onActivate.AddListener(ReenableTutorialQuests);
-        GameObject manager = Util.GetByPath("Managers");
-        Game game = manager.GetComponent<Game>();
-        game.SetToStory();
+        if (act1QuestStates.StateID >= 2)
+        {
+            ReenableTutorialQuests();
+        }
+    }
+
+    private static void Act1QuestHandler(int stateID)
+    {
+        switch (stateID)
+        {
+            case 0:
+                break; // Do nothing on initial cutscene
+            case 1:
+                AdvanceToEndOfTutorial(); break;
+            case 2:
+                ReenableTutorialQuests(); EnableFriendsInCutscene(); break;
+            case 3:
+                ReenableTutorialQuests(); break;
+        }
     }
 
     private static void AdvanceToEndOfTutorial()
@@ -29,10 +41,18 @@ static class TutorialQuestMods
         QuestStates act1QuestStates = act1.GetComponent<QuestStates>();
         if (act1QuestStates.StateID < 2)
         {
-            act1QuestStates.ProgressState(2);
+            act1QuestStates.SetState(2);
+            EnableFriendsInCutscene();
             ReenableTutorialQuests();
         }
-        act1QuestStates.states[2].stateObjects[0].SetActive(true); // Reenable End object to try to fix Cutscene in Start With Freeplay = true
+    }
+
+    private static void EnableFriendsInCutscene()
+    {
+        // Reenable End object to try to fix Cutscene in Start With Freeplay = true
+        GameObject act1 = Util.GetByPath("NorthWest (Tutorial Island)/Act 1");
+        QuestStates act1QuestStates = act1.GetComponent<QuestStates>();
+        act1QuestStates.states[2].stateObjects[0].SetActive(true);
     }
 
     private static void ReenableTutorialQuests()

--- a/GatorRando/questMods/TutorialQuestMods.cs
+++ b/GatorRando/questMods/TutorialQuestMods.cs
@@ -39,10 +39,10 @@ static class TutorialQuestMods
     {
         GameObject act1 = Util.GetByPath("NorthWest (Tutorial Island)/Act 1");
         QuestStates act1QuestStates = act1.GetComponent<QuestStates>();
-        if (act1QuestStates.StateID < 2)
+        if (act1QuestStates.StateID <= 2)
         {
-            act1QuestStates.SetState(2);
-            EnableFriendsInCutscene();
+            act1QuestStates.SetState(3);
+            // EnableFriendsInCutscene();
             ReenableTutorialQuests();
         }
     }


### PR DESCRIPTION
- fixes lingering inventory bug
- fixes glider again
- changes goal to be on transition from flashback to credits
- load modifications to quests on a configurable delay
- When starting with freeplay, skip talking to Big Sis all together
- prevent connecting with save file that is ahead items-wise of server

Closes #73 , Closes #36, Closes #2 