### PR TITLE
Fix Glider and Bracelet Display by Refreshing PlayerItemManager on a delay

### DIFF
--- a/GatorRando/Archipelago/StateManager.cs
+++ b/GatorRando/Archipelago/StateManager.cs
@@ -64,6 +64,7 @@ public static class StateManager
             ItemHandling.ProcessItemQueue();
             MapManager.UpdateCoordsIfNeeded();
             BubbleManager.Update();
+            ItemUtil.RefreshPlayerItemManagerIfNeeded();
         }
     }
 


### PR DESCRIPTION
set glider unlocked a second time right before a refresh

fixes 4 bracelets not displaying and glider not working on receipt during game