### PR TITLE
Allow player to choose to trigger the goal at the start of the flashback

### DIFF
--- a/GatorRando/UIMods/RandoSettingsMenu.cs
+++ b/GatorRando/UIMods/RandoSettingsMenu.cs
@@ -91,10 +91,11 @@ static class RandoSettingsMenu
             "if unchecked, uses what locations as saved in the save file.");
 
             CreateSettingsToggle(viewportContent, 9, "Skip Prologue", "set before starting a new game. If true, will skip the prologue and set the player name to the slot name.");
+            CreateSettingsToggle(viewportContent, 10, "Goal Before Epilogue", "set before loading into a game. If true, goal will trigger on talking to your friends at the Playground when the flashback would start.");
 
             //Connect button
             CreateSettingsButton(viewportContent,
-                            13,
+                            14,
                             "Delete all AP Saves",
                             "delete all AP saves for Lil Gator Game. useful for cleaning up old runs",
                             SaveManager.EraseAllAPSaveData
@@ -105,9 +106,9 @@ static class RandoSettingsMenu
         // ReworkPlayerRename(viewportContent);
 
 
-        CreateSettingsToggle(viewportContent, 10, "Pause Speedrun for Item Get Dialogues", "If speedrun mode is on, skips through dialogue normally except dialogues that show what item you found");
-        CreateSettingsToggle(viewportContent, 11, "Hide Speedrun Timer", "Hides the speedrun timer (if you want to skip dialogue, but not see the timer)");
-        CreateSettingsOptions(viewportContent, 12, "Megaphone and Texting Logic?", "The megaphone helps you find friends' quests. Texting with Jill helps you find pots, chests, races, and cardboard." +
+        CreateSettingsToggle(viewportContent, 11, "Pause Speedrun for Item Get Dialogues", "If speedrun mode is on, skips through dialogue normally except dialogues that show what item you found");
+        CreateSettingsToggle(viewportContent, 12, "Hide Speedrun Timer", "Hides the speedrun timer (if you want to skip dialogue, but not see the timer)");
+        CreateSettingsOptions(viewportContent, 13, "Megaphone and Texting Logic?", "The megaphone helps you find friends' quests. Texting with Jill helps you find pots, chests, races, and cardboard." +
             "This setting changes how these tools work. \"logic\": use randomizer logic to show only valid checks, \"checks only\": show all possible checks, \"original\": original behavior", ["logic", "checks only", "original"]);
 
         newSettingsMenu = newMenu.GetComponent<UISubMenu>();
@@ -229,10 +230,11 @@ static class RandoSettingsMenu
 
     public static CheckfinderBehavior GetCheckfinderBehavior() => (CheckfinderBehavior)Settings.s.ReadInt("megaphone and texting logic?");
 
-    public static bool IsPrologueToBeSkipped() => Settings.s.ReadBool("skip prologue", true);
+    public static bool IsPrologueToBeSkipped() => Settings.s.ReadBool("skip prologue", false);
 
     public static bool PauseForItemGet() => Settings.s.ReadBool("Pause Speedrun for Item Get Dialogues".ToLower(), true);
     public static bool HideSpeedrunTimer() => Settings.s.ReadBool("hide speedrun timer", true);
 
     public static bool IsCollectCountedAsChecked() => Settings.s.ReadBool("!collect counts as checked", true);
+    public static bool IsGoalBeforeEpilogue() => Settings.s.ReadBool("goal before epilogue", false);
 }

--- a/GatorRando/patches/GamePatch.cs
+++ b/GatorRando/patches/GamePatch.cs
@@ -1,0 +1,19 @@
+using GatorRando.Archipelago;
+using GatorRando.UIMods;
+using HarmonyLib;
+
+namespace GatorRando.Patches;
+
+[HarmonyPatch(typeof(Game))]
+static class GamePatch
+{
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(Game.SetWorldState), [typeof(WorldState), typeof(bool), typeof(bool)])]
+    static void PreSetWorldState(WorldState newWorldState)
+    {
+        if (newWorldState == WorldState.Flashback & RandoSettingsMenu.IsGoalBeforeEpilogue())
+        {
+            ConnectionManager.SendGoal();
+        }
+    }
+}


### PR DESCRIPTION
Adds a setting to the Rando Settings menu so that a player can check the box so that the Goal trigger happens at the beginning of the flashback (select this setting before loading into a save file)