### PR TITLE
Catch NullReferenceException caused during disconnection on title screen

### DIFF
--- a/GatorRando/Archipelago/ConnectionManager.cs
+++ b/GatorRando/Archipelago/ConnectionManager.cs
@@ -96,7 +96,14 @@ public static class ConnectionManager
 
     public static void UnregisterItemReceivedListener()
     {
-        session.Items.ItemReceived -= OnItemReceived;
+        try
+        {
+            session.Items.ItemReceived -= OnItemReceived;
+        }
+        catch (NullReferenceException)
+        {
+            Plugin.LogWarn("ItemReceived Listener had not yet been registered");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Solves NullReferenceException caused by the ItemReceived handler not yet being registered if a save had not yet been loaded, since Disconnect() will unconditionally try to unregister it.

This fix means that if you become disconnected on the title screen, you can now reconnect